### PR TITLE
Implement price repository structure

### DIFF
--- a/src/main/java/com/example/test/price/domain/ports/out/PriceRepositoryPort.java
+++ b/src/main/java/com/example/test/price/domain/ports/out/PriceRepositoryPort.java
@@ -1,0 +1,18 @@
+package com.example.test.price.domain.ports.out;
+
+import com.example.test.price.domain.models.Price;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface PriceRepositoryPort {
+    /**
+     * Retrieves a list of prices for a given moment in time, product and brand
+     *
+     * @param dateTime      the application date
+     * @param productId the product identifier
+     * @param brandId   the brand (store) identifier
+     * @return the applicable Price object, or null if none found
+     */
+    List<Price> findProductPricesAt(LocalDateTime dateTime, Long productId, Long brandId);
+}

--- a/src/main/java/com/example/test/price/infrastructure/adapters/repositories/PriceRepositoryAdapter.java
+++ b/src/main/java/com/example/test/price/infrastructure/adapters/repositories/PriceRepositoryAdapter.java
@@ -1,0 +1,14 @@
+package com.example.test.price.infrastructure.adapters.repositories;
+
+import com.example.test.price.domain.models.Price;
+import com.example.test.price.domain.ports.out.PriceRepositoryPort;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class PriceRepositoryAdapter implements PriceRepositoryPort {
+    @Override
+    public List<Price> findProductPricesAt(LocalDateTime dateTime, Long productId, Long brandId) {
+        return List.of();
+    }
+}

--- a/src/main/java/com/example/test/price/infrastructure/adapters/repositories/jparepository/JpaPriceRepository.java
+++ b/src/main/java/com/example/test/price/infrastructure/adapters/repositories/jparepository/JpaPriceRepository.java
@@ -1,0 +1,7 @@
+package com.example.test.price.infrastructure.adapters.repositories.jparepository;
+
+import com.example.test.price.infrastructure.adapters.repositories.jparepository.entities.JpaPriceEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JpaPriceRepository extends JpaRepository<JpaPriceEntity, Long> {
+}

--- a/src/main/java/com/example/test/price/infrastructure/adapters/repositories/jparepository/entities/JpaPriceEntity.java
+++ b/src/main/java/com/example/test/price/infrastructure/adapters/repositories/jparepository/entities/JpaPriceEntity.java
@@ -1,0 +1,78 @@
+package com.example.test.price.infrastructure.adapters.repositories.jparepository.entities;
+
+
+import jakarta.persistence.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "price")
+public class JpaPriceEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column
+    private Long brandId;
+
+    @Column
+    private LocalDateTime startDate;
+
+    @Column
+    private LocalDateTime endDate;
+
+    @Column
+    private Long priceList;
+
+    @Column
+    private Long productId;
+
+    @Column
+    private Integer priority;
+
+    @Column
+    private BigDecimal price;
+
+    @Column
+    private String currency;
+
+    protected JpaPriceEntity() {}
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getBrandId() {
+        return brandId;
+    }
+
+    public LocalDateTime getStartDate() {
+        return startDate;
+    }
+
+    public LocalDateTime getEndDate() {
+        return endDate;
+    }
+
+    public Long getPriceList() {
+        return priceList;
+    }
+
+    public Long getProductId() {
+        return productId;
+    }
+
+    public Integer getPriority() {
+        return priority;
+    }
+
+    public BigDecimal getPrice() {
+        return price;
+    }
+
+    public String getCurrency() {
+        return currency;
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,5 +3,5 @@ spring.datasource.url=jdbc:h2:mem:testdb
 spring.datasource.driverClassName=org.h2.Driver
 spring.datasource.username=sa
 spring.datasource.password=
-spring.jpa.hibernate.ddl-auto=update
+spring.jpa.hibernate.ddl-auto=validate
 spring.h2.console.enabled=true


### PR DESCRIPTION
- Add JPA price entity with persistence annotations
- Add JPA repository interface for price data access
- Create repository adapter implementing domain port
- Create repository port interface with query method
- Change hibernate.ddl-auto from update to validate, since flyway will take care of the DB schema

This commit sets up the infrastructure for price data persistence using a hexagonal architecture approach with repository ports.