### PR TITLE
Implement Price repository with JPA integration

### DIFF
--- a/src/main/java/com/example/test/price/domain/models/Price.java
+++ b/src/main/java/com/example/test/price/domain/models/Price.java
@@ -7,13 +7,13 @@ public class Price{
     Long brandId;
     LocalDateTime startDate;
     LocalDateTime endDate;
-    Integer priceList;
+    Long priceList;
     Long productId;
     Integer priority;
     BigDecimal price;
     String currency;
 
-    public Price(Long brandId, LocalDateTime startDate, LocalDateTime endDate, Integer priceList, Long productId, Integer priority, BigDecimal price, String currency) {
+    public Price(Long brandId, LocalDateTime startDate, LocalDateTime endDate, Long priceList, Long productId, Integer priority, BigDecimal price, String currency) {
         this.brandId = brandId;
         this.startDate = startDate;
         this.endDate = endDate;
@@ -36,7 +36,7 @@ public class Price{
         return endDate;
     }
 
-    public Integer getPriceList() {
+    public Long getPriceList() {
         return priceList;
     }
 

--- a/src/main/java/com/example/test/price/domain/ports/out/PriceRepositoryPort.java
+++ b/src/main/java/com/example/test/price/domain/ports/out/PriceRepositoryPort.java
@@ -4,15 +4,28 @@ import com.example.test.price.domain.models.Price;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 public interface PriceRepositoryPort {
     /**
-     * Retrieves a list of prices for a given moment in time, product and brand
+     * Retrieves the price for a given moment in time, product and brand
+     * If multiple rates overlap in their date ranges, the one with the highest priority is returned.
      *
-     * @param dateTime      the application date
+     * @param dateTime      the application date and time
      * @param productId the product identifier
      * @param brandId   the brand (store) identifier
-     * @return the applicable Price object, or null if none found
+     * @return an Optional containing the applicable Price if one exists, or an empty Optional if none is found
      */
-    List<Price> findProductPricesAt(LocalDateTime dateTime, Long productId, Long brandId);
+    Optional<Price> findApplicablePriceAt(LocalDateTime dateTime, Long productId, Long brandId);
+
+
+    /**
+     * Retrieves a list of prices for a given moment in time, product and brand
+     *
+     * @param dateTime      the application date and time
+     * @param productId the product identifier
+     * @param brandId   the brand (store) identifier
+     * @return the list of applicable price objects, empty if none found
+     */
+    List<Price> findApplicablePricesAt(LocalDateTime dateTime, Long productId, Long brandId);
 }

--- a/src/main/java/com/example/test/price/infrastructure/adapters/repositories/PriceRepositoryAdapter.java
+++ b/src/main/java/com/example/test/price/infrastructure/adapters/repositories/PriceRepositoryAdapter.java
@@ -2,13 +2,37 @@ package com.example.test.price.infrastructure.adapters.repositories;
 
 import com.example.test.price.domain.models.Price;
 import com.example.test.price.domain.ports.out.PriceRepositoryPort;
+import com.example.test.price.infrastructure.adapters.repositories.jparepository.JpaPriceRepository;
+import com.example.test.price.infrastructure.adapters.repositories.jparepository.entities.JpaPriceEntity;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
+@Component
 public class PriceRepositoryAdapter implements PriceRepositoryPort {
+    private final JpaPriceRepository jpaPriceRepository;
+
+    @Autowired
+    public PriceRepositoryAdapter(JpaPriceRepository jpaPriceRepository) {
+        this.jpaPriceRepository = jpaPriceRepository;
+    }
+
     @Override
-    public List<Price> findProductPricesAt(LocalDateTime dateTime, Long productId, Long brandId) {
-        return List.of();
+    public Optional<Price> findApplicablePriceAt(LocalDateTime dateTime, Long productId, Long brandId) {
+        Optional<JpaPriceEntity> priceEntity = jpaPriceRepository.findApplicablePriceAt(dateTime, productId, brandId);
+        return priceEntity.map(JpaPriceEntity::toDomainModel);
+    }
+
+    @Override
+    public List<Price> findApplicablePricesAt(LocalDateTime dateTime, Long productId, Long brandId) {
+        List<JpaPriceEntity> entities = jpaPriceRepository.findApplicablePricesAt(dateTime, productId, brandId);
+
+        return entities.stream()
+                .map(JpaPriceEntity::toDomainModel)
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/example/test/price/infrastructure/adapters/repositories/jparepository/JpaPriceRepository.java
+++ b/src/main/java/com/example/test/price/infrastructure/adapters/repositories/jparepository/JpaPriceRepository.java
@@ -2,6 +2,47 @@ package com.example.test.price.infrastructure.adapters.repositories.jparepositor
 
 import com.example.test.price.infrastructure.adapters.repositories.jparepository.entities.JpaPriceEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
 
 public interface JpaPriceRepository extends JpaRepository<JpaPriceEntity, Long> {
+
+    /**
+     * Find the price with the highest priority applicable at a specific date time for a product and brand
+     *
+     * @param dateTime the date and time to check
+     * @param productId the product ID
+     * @param brandId the brand ID
+     * @return an Optional containing the applicable PriceEntity if one exists, or an empty Optional if none is found
+     */
+    @Query("SELECT p FROM JpaPriceEntity p " +
+            "WHERE p.productId = :productId " +
+            "AND p.brandId = :brandId " +
+            "AND :dateTime BETWEEN p.startDate AND p.endDate " +
+            "ORDER BY p.priority DESC")
+    Optional<JpaPriceEntity> findApplicablePriceAt(
+            @Param("dateTime") LocalDateTime dateTime,
+            @Param("productId") Long productId,
+            @Param("brandId") Long brandId);
+
+    /**
+     * Retrieves a list of prices at a specific date time for a product and brand
+     *
+     * @param dateTime the date and time to check
+     * @param productId the product ID
+     * @param brandId the brand ID
+     * @return the list of prices that are applicable, if none results an empty list
+     */
+    @Query("SELECT p FROM JpaPriceEntity p " +
+            "WHERE p.productId = :productId " +
+            "AND p.brandId = :brandId " +
+            "AND :dateTime BETWEEN p.startDate AND p.endDate")
+    List<JpaPriceEntity> findApplicablePricesAt(
+            @Param("dateTime") LocalDateTime dateTime,
+            @Param("productId") Long productId,
+            @Param("brandId") Long brandId);
 }

--- a/src/main/java/com/example/test/price/infrastructure/adapters/repositories/jparepository/entities/JpaPriceEntity.java
+++ b/src/main/java/com/example/test/price/infrastructure/adapters/repositories/jparepository/entities/JpaPriceEntity.java
@@ -1,6 +1,7 @@
 package com.example.test.price.infrastructure.adapters.repositories.jparepository.entities;
 
 
+import com.example.test.price.domain.models.Price;
 import jakarta.persistence.*;
 
 import java.math.BigDecimal;
@@ -75,4 +76,19 @@ public class JpaPriceEntity {
     public String getCurrency() {
         return currency;
     }
+
+
+    public Price toDomainModel() {
+        return new Price(
+                this.brandId,
+                this.startDate,
+                this.endDate,
+                this.priceList,
+                this.productId,
+                this.priority,
+                this.price,
+                this.currency
+        );
+    }
+
 }

--- a/src/main/resources/db/migration/V1__Create_price_table.sql
+++ b/src/main/resources/db/migration/V1__Create_price_table.sql
@@ -1,4 +1,4 @@
-idx_price_datetime_product_brand TABLE price (
+CREATE TABLE price (
     id BIGINT AUTO_INCREMENT PRIMARY KEY,
     brand_id BIGINT NOT NULL,
     start_date TIMESTAMP NOT NULL,


### PR DESCRIPTION
- Updated Price domain model to use Long for priceList to match database schema
- Enhanced PriceRepositoryPort interface with more specific methods:
  - findApplicablePriceAt: returns Optional<Price> with highest priority
  - findApplicablePricesAt: returns List<Price> for all applicable prices
- Implemented PriceRepositoryAdapter with proper JPA integration
- Added JPQL queries to JpaPriceRepository for finding prices at specific datetime
- Added toDomainModel() mapper to JpaPriceEntity for clean domain conversion

These changes complete the repository layer implementation, allowing the application to properly retrieve price information based on product, brand, and application datetime with priority handling.