### PR TITLE
Implement price service with controller and two API approaches

### DIFF
--- a/src/main/java/com/example/test/price/application/services/PricePubicApiService.java
+++ b/src/main/java/com/example/test/price/application/services/PricePubicApiService.java
@@ -1,0 +1,57 @@
+package com.example.test.price.application.services;
+
+import com.example.test.price.domain.models.Price;
+import com.example.test.price.domain.ports.in.PricePublicApiPort;
+import com.example.test.price.domain.ports.out.PriceRepositoryPort;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.List;
+
+@Service
+public class PricePubicApiService implements PricePublicApiPort {
+
+
+    /*
+     * In this service, two different approaches are demonstrated for finding the applicable price with the highest priority
+     * for a given date, time, product ID, and brand ID.
+     *
+     * The first approach (`findApplicablePriceAtV1`) delegates the responsibility of selecting the highest priority price
+     * to the database layer. By calling `findApplicablePriceAt` on the repository, it expects the repository to execute a
+     * query that directly retrieves the price with the highest priority for the specified parameters. This method is
+     * optimized for performance as it reduces the amount of data transferred and processed in the application layer.
+     *
+     * The second approach (`findApplicablePriceAtV2`) retrieves all applicable prices for the given date, product, and brand
+     * from the repository and then uses Java streams to select the price with the highest priority. This approach adheres
+     * more strictly to the principles of hexagonal architecture and the single responsibility principle, where the repository
+     * is only responsible for data access, and the service layer encapsulates the business logic. While this may be less
+     * efficient in scenarios with a large number of applicable prices, it offers better separation of concerns, which can
+     * enhance maintainability and testability. Similar to the first approach, if there are multiple prices with the same
+     * highest priority, the `max` operation will select one based on the natural ordering of the Price objects.
+     *
+     */
+
+    private final PriceRepositoryPort priceRepositoryPort;
+
+    @Autowired
+    public PricePubicApiService(PriceRepositoryPort priceRepositoryPort) {
+        this.priceRepositoryPort = priceRepositoryPort;
+    }
+
+    @Override
+    public Price findApplicablePriceAtV1(LocalDateTime dateTime, Long productId, Long brandId) {
+
+        return priceRepositoryPort.findApplicablePriceAt(dateTime, productId, brandId).orElse(null);
+
+    }
+
+    @Override
+    public Price findApplicablePriceAtV2(LocalDateTime dateTime, Long productId, Long brandId) {
+        List<Price> priceList = priceRepositoryPort.findApplicablePricesAt(dateTime, productId, brandId);
+        return priceList.stream()
+                .max(Comparator.comparing(Price::getPriority))
+                .orElse(null);
+    }
+}

--- a/src/main/java/com/example/test/price/domain/ports/in/PricePublicApiPort.java
+++ b/src/main/java/com/example/test/price/domain/ports/in/PricePublicApiPort.java
@@ -3,16 +3,28 @@ package com.example.test.price.domain.ports.in;
 import com.example.test.price.domain.models.Price;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public interface PricePublicApiPort {
     /**
      * Finds the price for a product and brand at a given time.
      * If multiple rates overlap in their date ranges, the one with the highest priority is returned.
      *
-     * @param time      the application date
+     * @param dateTime      the application date and time
      * @param productId the product identifier
      * @param brandId   the brand (store) identifier
-     * @return the applicable Price object, or null if none found
+     * @return the applicable Price object
      */
-    Price findApplicablePriceAt(LocalDateTime time, Long productId, Long brandId);
+    Price findApplicablePriceAtV1(LocalDateTime dateTime, Long productId, Long brandId);
+
+    /**
+     * Finds the price for a product and brand at a given time.
+     * If multiple rates overlap in their date ranges, the one with the highest priority is returned.
+     *
+     * @param dateTime      the application date and time
+     * @param productId the product identifier
+     * @param brandId   the brand (store) identifier
+     * @return the applicable Price object
+     */
+     Price findApplicablePriceAtV2(LocalDateTime dateTime, Long productId, Long brandId);
 }

--- a/src/main/java/com/example/test/price/infrastructure/adapters/httpapi/PriceController.java
+++ b/src/main/java/com/example/test/price/infrastructure/adapters/httpapi/PriceController.java
@@ -1,0 +1,47 @@
+package com.example.test.price.infrastructure.adapters.httpapi;
+
+import com.example.test.price.domain.models.Price;
+import com.example.test.price.domain.ports.in.PricePublicApiPort;
+import com.example.test.price.infrastructure.adapters.httpapi.dtos.PriceResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDateTime;
+
+@RestController
+@RequestMapping("/api/prices")
+public class PriceController {
+
+    private final PricePublicApiPort pricePublicApiPort;
+
+    @Autowired
+    public PriceController(PricePublicApiPort pricePublicApiPort) {
+        this.pricePublicApiPort = pricePublicApiPort;
+    }
+
+    @GetMapping("/v1")
+    public ResponseEntity<PriceResponse> getApplicablePriceV1(
+            @RequestParam("dateTime") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime dateTime,
+            @RequestParam("productId") Long productId,
+            @RequestParam("brandId") Long brandId) {
+
+        Price price = pricePublicApiPort.findApplicablePriceAtV1(dateTime, productId, brandId);
+
+        return ResponseEntity.ok(PriceResponse.fromDomainModel(price));
+    }
+
+    @GetMapping("/v2")
+    public ResponseEntity<PriceResponse> getApplicablePriceV2(
+            @RequestParam("dateTime") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime dateTime,
+            @RequestParam("productId") Long productId,
+            @RequestParam("brandId") Long brandId) {
+
+        Price price = pricePublicApiPort.findApplicablePriceAtV2(dateTime, productId, brandId);
+
+        return ResponseEntity.ok(PriceResponse.fromDomainModel(price));
+    }
+
+
+}

--- a/src/main/java/com/example/test/price/infrastructure/adapters/httpapi/dtos/PriceResponse.java
+++ b/src/main/java/com/example/test/price/infrastructure/adapters/httpapi/dtos/PriceResponse.java
@@ -1,0 +1,69 @@
+package com.example.test.price.infrastructure.adapters.httpapi.dtos;
+
+import com.example.test.price.domain.models.Price;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+public class PriceResponse {
+    private Long productId;
+    private Long brandId;
+    private Long priceList;
+    private LocalDateTime startDate;
+    private LocalDateTime endDate;
+    private BigDecimal price;
+    private String currency;
+
+    public PriceResponse(Long productId, Long brandId, Long priceList,
+                         LocalDateTime startDate, LocalDateTime endDate,
+                         BigDecimal price, String currency) {
+        this.productId = productId;
+        this.brandId = brandId;
+        this.priceList = priceList;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.price = price;
+        this.currency = currency;
+    }
+
+
+    public Long getProductId() {
+        return productId;
+    }
+
+    public Long getBrandId() {
+        return brandId;
+    }
+
+    public Long getPriceList() {
+        return priceList;
+    }
+
+    public LocalDateTime getStartDate() {
+        return startDate;
+    }
+
+    public LocalDateTime getEndDate() {
+        return endDate;
+    }
+
+    public BigDecimal getPrice() {
+        return price;
+    }
+
+    public String getCurrency() {
+        return currency;
+    }
+
+    public static PriceResponse fromDomainModel(Price price) {
+        return new PriceResponse(
+                price.getProductId(),
+                price.getBrandId(),
+                price.getPriceList(),
+                price.getStartDate(),
+                price.getEndDate(),
+                price.getPrice(),
+                price.getCurrency()
+        );
+    }
+}

--- a/src/main/java/com/example/test/price/infrastructure/adapters/repositories/jparepository/JpaPriceRepository.java
+++ b/src/main/java/com/example/test/price/infrastructure/adapters/repositories/jparepository/JpaPriceRepository.java
@@ -23,7 +23,7 @@ public interface JpaPriceRepository extends JpaRepository<JpaPriceEntity, Long> 
             "WHERE p.productId = :productId " +
             "AND p.brandId = :brandId " +
             "AND :dateTime BETWEEN p.startDate AND p.endDate " +
-            "ORDER BY p.priority DESC")
+            "ORDER BY p.priority DESC LIMIT 1")
     Optional<JpaPriceEntity> findApplicablePriceAt(
             @Param("dateTime") LocalDateTime dateTime,
             @Param("productId") Long productId,


### PR DESCRIPTION
- Add PriceController with version 1 and 2 endpoints
- Update PricePublicApiPort interface with two implementation methods
- Create PricePubicApiService with database and stream-based approaches
- Add PriceResponse DTO for API responses
- Fix JpaPriceRepository by adding LIMIT 1 to findApplicablePriceAt query